### PR TITLE
Set up new schema format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,6 @@
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "javascript.preferences.importModuleSpecifier": "non-relative",
-  "cSpell.words": [
-    "clsx"
-  ],
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/db/migrator/convert-schema.ts
+++ b/src/db/migrator/convert-schema.ts
@@ -23,9 +23,9 @@ export const convertJsonSchemaToDatabaseSchema = (
       rootTable.columns.push({
         name: key,
         type: getSqlType(prop.type),
-        notnull: jsonSchema.required?.includes(key) ? 1 : 0,
-        dflt_value: prop.default as any,
-        pk: key === 'id' ? 1 : 0,
+        notNull: jsonSchema.required?.includes(key),
+        defaultValue: prop.default as any,
+        primaryKey: key === 'id' ,
       });
     } else {
       console.warn(`property of type ${typeof prop} not supported`);

--- a/src/db/migrator/diff-schema.ts
+++ b/src/db/migrator/diff-schema.ts
@@ -128,7 +128,7 @@ const getColumnDef = (column: SqliteColumnSchema) => {
   return [
     escapeIdIfNeeded(column.name),
     column.type,
-    ...(column.pk === 1 ? ['PRIMARY KEY'] : []),
-    ...(column.notnull ? ['NOT NULL'] : []),
+    ...(column.primaryKey ? ['PRIMARY KEY'] : []),
+    ...(column.notNull ? ['NOT NULL'] : []),
   ].join(' ');
 };

--- a/src/db/migrator/introspect-database.ts
+++ b/src/db/migrator/introspect-database.ts
@@ -1,5 +1,9 @@
 import sqlQuery from './introspect-database.sql?raw';
-import type { SqliteTableSchema } from './types';
+import type {
+  SqliteColumnSchema,
+  SqliteColumnSchemaRaw,
+  SqliteTableSchema,
+} from './types';
 
 export const introspectDatabase = async (
   queryDb: (sql: string) => any[] | Promise<any[]>
@@ -8,7 +12,24 @@ export const introspectDatabase = async (
 
   for (const item of items) {
     if (typeof item.columns === 'string') {
-      item.columns = JSON.parse(item.columns);
+      const columns = JSON.parse(item.columns) as SqliteColumnSchemaRaw[];
+
+      const cleaned: SqliteColumnSchema[] = [];
+
+      for (const column of columns) {
+        const { cid, name, type, notnull, dflt_value, pk } = column;
+
+        cleaned.push({
+          cid,
+          name,
+          type,
+          notNull: notnull === 1,
+          defaultValue: dflt_value,
+          primaryKey: pk === 1,
+        });
+      }
+
+      item.columns = cleaned;
     }
   }
 

--- a/src/db/migrator/migrator.test.ts
+++ b/src/db/migrator/migrator.test.ts
@@ -31,17 +31,24 @@ describe('migrator', () => {
       {
         "columns": [
           {
-            "dflt_value": undefined,
+            "defaultValue": undefined,
             "name": "id",
-            "notnull": 0,
-            "pk": 1,
+            "notNull": false,
+            "primaryKey": true,
             "type": "INTEGER",
           },
           {
-            "dflt_value": undefined,
+            "defaultValue": undefined,
             "name": "name",
-            "notnull": 1,
-            "pk": 0,
+            "notNull": true,
+            "primaryKey": false,
+            "type": "TEXT",
+          },
+          {
+            "defaultValue": undefined,
+            "name": "description",
+            "notNull": false,
+            "primaryKey": false,
             "type": "TEXT",
           },
           {
@@ -124,17 +131,24 @@ describe('diff tables', () => {
           "table": {
             "columns": [
               {
-                "dflt_value": undefined,
+                "defaultValue": undefined,
                 "name": "id",
-                "notnull": 0,
-                "pk": 1,
+                "notNull": false,
+                "primaryKey": true,
                 "type": "INTEGER",
               },
               {
-                "dflt_value": undefined,
+                "defaultValue": undefined,
                 "name": "name",
-                "notnull": 1,
-                "pk": 0,
+                "notNull": true,
+                "primaryKey": false,
+                "type": "TEXT",
+              },
+              {
+                "defaultValue": undefined,
+                "name": "description",
+                "notNull": false,
+                "primaryKey": false,
                 "type": "TEXT",
               },
               {
@@ -204,10 +218,10 @@ describe('diff tables', () => {
       [
         {
           "column": {
-            "dflt_value": undefined,
+            "defaultValue": undefined,
             "name": "type",
-            "notnull": 1,
-            "pk": 0,
+            "notNull": true,
+            "primaryKey": false,
             "type": "TEXT",
           },
           "tableName": "categories",
@@ -237,15 +251,15 @@ describe('diff tables', () => {
         {
           name: '_migrations',
           columns: [
-            { name: 'id', type: 'TEXT', notnull: 1, pk: 1 },
-            { name: 'sql', type: 'TEXT', notnull: 1, pk: 0 },
+            { name: 'id', type: 'TEXT', notNull: true, primaryKey: true },
+            { name: 'sql', type: 'TEXT', notNull: true },
           ],
         },
         {
           name: '_migrations',
           columns: [
-            { name: 'id', type: 'TEXT', notnull: 1, pk: 1 },
-            { name: 'json', type: 'TEXT', notnull: 1, pk: 0 },
+            { name: 'id', type: 'TEXT', notNull: true, primaryKey: true },
+            { name: 'json', type: 'TEXT', notNull: true },
           ],
         },
       ]

--- a/src/db/migrator/migrator.test.ts
+++ b/src/db/migrator/migrator.test.ts
@@ -51,13 +51,6 @@ describe('migrator', () => {
             "primaryKey": false,
             "type": "TEXT",
           },
-          {
-            "dflt_value": undefined,
-            "name": "description",
-            "notnull": 0,
-            "pk": 0,
-            "type": "TEXT",
-          },
         ],
         "name": "categories",
       }
@@ -149,13 +142,6 @@ describe('diff tables', () => {
                 "name": "description",
                 "notNull": false,
                 "primaryKey": false,
-                "type": "TEXT",
-              },
-              {
-                "dflt_value": undefined,
-                "name": "description",
-                "notnull": 0,
-                "pk": 0,
                 "type": "TEXT",
               },
             ],

--- a/src/db/migrator/shared.ts
+++ b/src/db/migrator/shared.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema6, JSONSchema6TypeName } from 'json-schema';
-import type { SqliteColumnType, SqliteTableSchema } from './types';
+import type { PrimativeColumnType, SqliteTableSchema } from './types';
 
 export const escapeIdIfNeeded = (text: string) => {
   // no-op for now
@@ -8,7 +8,7 @@ export const escapeIdIfNeeded = (text: string) => {
 
 export const getSqlType = (
   typeName?: JSONSchema6TypeName | JSONSchema6TypeName[]
-): SqliteColumnType => {
+): PrimativeColumnType => {
   if (typeName === 'string') {
     return 'TEXT';
   } else if (typeName === 'integer') {

--- a/src/db/migrator/types.ts
+++ b/src/db/migrator/types.ts
@@ -1,12 +1,47 @@
 import { z } from 'zod';
 
+export const PrimativeColumnType = z.enum(['INTEGER', 'REAL', 'TEXT', 'BLOB']);
+export type PrimativeColumnType = z.infer<typeof PrimativeColumnType>;
+
+const RefColumnType = z.object({
+  type: z.literal('ref'),
+  table: z.string(),
+});
+
+const ArrayColumnType = z.object({
+  type: z.literal('array'),
+  item: PrimativeColumnType,
+});
+type ArrayColumnType = z.infer<typeof ArrayColumnType>;
+
+const ColumnType = z.union([
+  PrimativeColumnType,
+  // z.object({
+  //   type: z.literal('primative'),
+  //   item: PrimativeColumnType,
+  // }),
+  RefColumnType,
+  ArrayColumnType,
+]);
+type ColumnType = z.infer<typeof ColumnType>;
+
+// export const SqliteColumnSchema = z.object({
+//   cid: z.number().int().nullish(),
+//   name: z.string(),
+//   type: ColumnType,
+//   notnull: z.union([z.literal(0), z.literal(1)]),
+//   dflt_value: z.string().nullish(),
+//   pk: z.number().int(),
+// });
+
+/** TODO: rename the variables like this */
 export const SqliteColumnSchema = z.object({
   cid: z.number().int().nullish(),
   name: z.string(),
-  type: z.string(), // SqliteColumnType
-  notnull: z.union([z.literal(0), z.literal(1)]),
-  dflt_value: z.string().nullish(),
-  pk: z.number().int(),
+  type: ColumnType,
+  notNull: z.boolean().default(false),
+  defaultValue: z.string().nullish(),
+  primaryKey: z.boolean().default(false),
 });
 
 export const SqliteTableSchema = z.object({
@@ -19,8 +54,6 @@ export const SqliteTableSchema = z.object({
 });
 
 export type SqliteTableSchema = z.infer<typeof SqliteTableSchema>;
-
-export type SqliteColumnType = 'INTEGER' | 'REAL' | 'TEXT' | 'BLOB';
 
 export type SqliteColumnSchema = z.infer<typeof SqliteColumnSchema>;
 

--- a/src/db/migrator/types.ts
+++ b/src/db/migrator/types.ts
@@ -25,24 +25,32 @@ const ColumnType = z.union([
 ]);
 type ColumnType = z.infer<typeof ColumnType>;
 
-// export const SqliteColumnSchema = z.object({
-//   cid: z.number().int().nullish(),
-//   name: z.string(),
-//   type: ColumnType,
-//   notnull: z.union([z.literal(0), z.literal(1)]),
-//   dflt_value: z.string().nullish(),
-//   pk: z.number().int(),
-// });
+export const SqliteColumnSchemaRaw = z.object({
+  cid: z.number().int().nullish(),
+  name: z.string(),
+  type: ColumnType,
+  notnull: z.union([z.literal(0), z.literal(1)]),
+  dflt_value: z.string().nullish(),
+  pk: z.union([z.literal(0), z.literal(1)]),
+});
+export type SqliteColumnSchemaRaw = z.infer<typeof SqliteColumnSchemaRaw>;
 
-/** TODO: rename the variables like this */
 export const SqliteColumnSchema = z.object({
   cid: z.number().int().nullish(),
   name: z.string(),
   type: ColumnType,
-  notNull: z.boolean().default(false),
+  /** default false */
+  notNull: z.boolean().nullish(),
   defaultValue: z.string().nullish(),
-  primaryKey: z.boolean().default(false),
+  /** default false */
+  primaryKey: z.boolean().nullish(),
 });
+
+export const SqliteTableSchemaRaw = z.object({
+  name: z.string(),
+  columns: z.array(SqliteColumnSchemaRaw),
+});
+export type SqliteTableSchemaRaw = z.infer<typeof SqliteTableSchemaRaw>;
 
 export const SqliteTableSchema = z.object({
   // type: z.literal("table").optional(),
@@ -52,7 +60,6 @@ export const SqliteTableSchema = z.object({
   // rootpage: number;
   // sql: string;
 });
-
 export type SqliteTableSchema = z.infer<typeof SqliteTableSchema>;
 
 export type SqliteColumnSchema = z.infer<typeof SqliteColumnSchema>;

--- a/src/routes/[entity]/create.page.tsx
+++ b/src/routes/[entity]/create.page.tsx
@@ -2,7 +2,7 @@ import validator from '@rjsf/validator-ajv8';
 import {
   Link,
   navigate,
-  PageProps,
+  type PageProps,
   useQueryClient,
   useServerSideMutation,
   useServerSideQuery,

--- a/src/routes/[entity]/index.page.tsx
+++ b/src/routes/[entity]/index.page.tsx
@@ -1,4 +1,4 @@
-import { Link, PageProps, useServerSideQuery } from 'rakkasjs';
+import { Link, type PageProps, useServerSideQuery } from 'rakkasjs';
 import { For } from 'react-loops';
 import { Show } from 'src/components/show';
 import { loadEntityData } from 'src/db/load-entity-data';
@@ -23,7 +23,9 @@ const EntityPage = ({ params }: PageProps) => {
     }
   );
 
-  const { entities, schema, schemaId } = data ?? {};
+  const results = data.status === 'fulfilled' ? data.value : undefined;
+
+  const { entities, schema, schemaId } = results ?? {};
 
   return (
     <div className="p-2 flex flex-col gap-2">

--- a/src/routes/[entity]/index.page.tsx
+++ b/src/routes/[entity]/index.page.tsx
@@ -3,16 +3,21 @@ import { For } from 'react-loops';
 import { Show } from 'src/components/show';
 import { loadEntityData } from 'src/db/load-entity-data';
 import { compactStringify } from 'src/utils/compact-stringify';
+import { wrapServerQuery } from 'src/utils/wrap-server-query';
 import { ViewEntity } from '../../components/view-entity';
 
 const EntityPage = ({ params }: PageProps) => {
+  console.log('EntityPage');
   const entityName = params.entity;
 
   // TODO: figure out how to filter out default urls like favicon.ico
   // more effectively to avoid error messagesq
 
   const { data, refetch } = useServerSideQuery(
-    (context) => loadEntityData({ context, entityName, withEntities: true }),
+    (context) =>
+      wrapServerQuery(() =>
+        loadEntityData({ context, entityName, withEntities: true })
+      ),
     {
       key: `view-all-${entityName}`,
     }

--- a/src/routes/database/index.page.tsx
+++ b/src/routes/database/index.page.tsx
@@ -16,7 +16,7 @@ import {
 } from 'src/db/migrator/diff-schema';
 import { introspectDatabase } from 'src/db/migrator/introspect-database';
 import { isUserTable } from 'src/db/migrator/shared';
-import { SchemaTable, systemTables } from 'src/db/migrator/system-tables';
+import { type SchemaTable, systemTables } from 'src/db/migrator/system-tables';
 import { getOrm } from 'src/db/orm';
 import ErrorPage from 'src/routes/$error';
 import { wrapServerQuery } from 'src/utils/wrap-server-query';

--- a/src/routes/index.page.tsx
+++ b/src/routes/index.page.tsx
@@ -1,4 +1,4 @@
-import { Link, Page, useServerSideQuery } from 'rakkasjs';
+import { Link, type Page, useServerSideQuery } from 'rakkasjs';
 import { SYSTEM_TABLES } from 'src/db/migrator/shared';
 import { getOrm } from 'src/db/orm';
 import { For } from 'react-loops';

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -1,15 +1,17 @@
-// This is the main layout of our app. It renders the header and the footer.
-
-import { Head, Layout, Link, StyledLink, useServerSideQuery } from 'rakkasjs';
-
+import clsx from 'clsx';
+import {
+  Head,
+  type Layout,
+  Link,
+  StyledLink,
+  useServerSideQuery,
+} from 'rakkasjs';
+import { IconMenu, IconX } from 'src/components/icons';
 import { SYSTEM_TABLES } from 'src/db/migrator/shared';
 import { getOrm } from 'src/db/orm';
-import 'tailwindcss/tailwind.css';
-import clsx from 'clsx';
-import { IconMenu, IconX } from 'src/components/icons';
 import { useSidebar } from 'src/shared/sidebar';
 import { wrapServerQuery } from 'src/utils/wrap-server-query';
-import ErrorPage from 'src/routes/$error';
+import 'tailwindcss/tailwind.css';
 
 const Sidebar = () => {
   const { data } = useServerSideQuery(

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -28,11 +28,11 @@ const Sidebar = () => {
 
   const isOpen = useSidebar((s) => s.isOpen);
 
-  if (data.status === 'rejected') {
-    return <ErrorPage error={data.reason} resetErrorBoundary={() => {}} />;
-  }
+  // if (data.status === 'rejected') {
+  //   return <ErrorPage error={data.reason} resetErrorBoundary={() => {}} />;
+  // }
 
-  const tables = data.value;
+  const tables = data.status === 'fulfilled' ? data.value : [];
   // if (!isOpen) return null;
 
   return (

--- a/src/routes/new-schema.page.tsx
+++ b/src/routes/new-schema.page.tsx
@@ -1,0 +1,70 @@
+import { SqliteTableSchema } from 'src/db/migrator/types';
+import type { z } from 'zod';
+
+export default function NewSchema() {
+  const chats: z.input<typeof SqliteTableSchema> = {
+    name: 'chats',
+    columns: [
+      {
+        name: 'id',
+        type: 'TEXT',
+      },
+      {
+        name: 'title',
+        type: 'TEXT',
+      },
+      {
+        name: 'users',
+        type: {
+          type: 'array',
+          item: 'TEXT',
+        },
+      },
+    ],
+  };
+
+  const tables = [SqliteTableSchema.parse(chats)];
+
+  for (const table of tables) {
+    const deleteMe = new Set();
+    for (const column of table.columns) {
+      if (typeof column.type === 'string') {
+        // do nothing
+      } else if (column.type.type === 'array') {
+        const newTable: z.input<typeof SqliteTableSchema> = {
+          name: `${table.name}_${column.name}`,
+          columns: [
+            {
+              name: 'id',
+              type: 'TEXT',
+            },
+            {
+              name: `${table.name}_id`,
+              type: 'TEXT',
+            },
+            // insert other fields
+            {
+              name: column.name,
+              type: column.type.item,
+            },
+          ],
+        };
+
+        tables.push(SqliteTableSchema.parse(newTable));
+
+        deleteMe.add(column);
+      }
+    }
+
+    table.columns = table.columns.filter((col) => !deleteMe.has(col));
+  }
+
+  return (
+    <>
+      <div>test</div>
+      {tables.map((table) => (
+        <pre>{JSON.stringify(table, undefined, 2)}</pre>
+      ))}
+    </>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "strict": true,
     "skipLibCheck": true,
     "moduleResolution": "Node",
@@ -15,5 +15,6 @@
     "types": ["vite/client"],
     "allowJs": true,
     "checkJs": true
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
Change from using JSON Schema to a more specific format that supports exactly the features of the cms. I think it will be easier to convert to/from JSON Schema as necessary instead of trying to map all features one-to-one with JSON Schema.

This updates the internal schema to something slightly nicer to use. In future PRs I will change the default code to store this schema format in the database instead of JSON Schema.